### PR TITLE
Fix golang build workflow

### DIFF
--- a/.github/workflows/golang-docker-build-push.yml
+++ b/.github/workflows/golang-docker-build-push.yml
@@ -16,9 +16,20 @@ on:
                 required: true
                 type: string
             build_context:
-                description: "Directory containing the Dockerfile"
+                description: "Docker build context"
                 required: true
                 type: string
+            build_file:
+                description: "Dockerfile"
+                required: true
+                type: string
+        secrets:
+            APP_ID:
+                required: true
+                description: "GitHub App ID to download AOH go modules"
+            APP_PRIVATE_KEY:
+                required: true
+                description: "GitHub App Private Key to download AOH go modules"
         outputs:
             image_tag:
                 description: "The full image tag that was built and pushed"
@@ -31,6 +42,14 @@ jobs:
         outputs:
             image_tag: ${{ steps.build_and_upload.outputs.image_tag }}
         steps:
+            - name: "Generate GitHub App Token"
+              uses: actions/create-github-app-token@v1
+              id: app-token
+              with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
+                  owner: ${{ inputs.org_name }}
+
             - name: "☁️ Checkout code"
               uses: actions/checkout@v4
               with:
@@ -47,7 +66,7 @@ jobs:
               id: build_and_upload
               run: |
                   cd ./src
-
+                  
                   if [ "${{ github.event_name }}" == "release" ]; then
                     git_hash=$(git rev-parse --short "$GITHUB_SHA")
                     TAG="${GITHUB_REF##*/}"
@@ -56,14 +75,12 @@ jobs:
                     TAG="${GITHUB_REF##*/}-${git_hash}"
                   fi
 
-                  cd ./${{ inputs.build_context }}
-
                   BASE_IMAGE_TAG="${{ inputs.image_prefix }}/${{ inputs.org_name }}/${{ inputs.app_name }}"
                   IMAGE_TAG="${BASE_IMAGE_TAG}:${TAG}"
                   echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
                   export IMAGE_TAG=${IMAGE_TAG}
-                  docker build . --build-arg GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} --build-arg REVISION=${TAG} -t ${IMAGE_TAG}
+                  docker build --build-arg GITHUB_USERNAME=x-access-token --build-arg GITHUB_TOKEN=${{ steps.app-token.outputs.token }} --build-arg REVISION=${TAG} -t ${IMAGE_TAG} -f ${{ inputs.build_file }} ${{ inputs.build_context }}
                   docker push ${IMAGE_TAG}
 
                   if [ "${{ github.event_name }}" == "release" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea


### PR DESCRIPTION
## Description
This PR fixes the golang workflow failing when pulling private go-lib module.

Example usage of workflow in golang repo with micro services.

```
jobs:
    build-and-push-image:
        strategy:
            fail-fast: false
            matrix:
                include:
                    - dockerfile: ./docker/room-mgmt.Dockerfile
                      name: vidconf-ion/room-mgmt
                    - dockerfile: ./docker/room-sentry.Dockerfile
                      name: vidconf-ion/room-sentry
                    - dockerfile: ./docker/room.Dockerfile
                      name: vidconf-ion/room
                    - dockerfile: ./docker/islb.Dockerfile
                      name: vidconf-ion/islb
                    - dockerfile: ./docker/sfu.Dockerfile
                      name: vidconf-ion/sfu
                    - dockerfile: ./docker/signal.Dockerfile
                      name: vidconf-ion/signal
        name: "Build & publish ${{ matrix.name }} Image"
        uses: mssfoobar/.github/.github/workflows/golang-docker-build-push.yml@main
        with:
            image_prefix: ghcr.io
            org_name: ${{ github.repository_owner }}
            app_name: ${{ matrix.name }}
            build_context: .
            build_file: ${{ matrix.dockerfile }}
        secrets:
            APP_ID: ${{ vars.DEPLOYMENT_APP_ID }}
            APP_PRIVATE_KEY: ${{ secrets.DEPLOYMENT_APP_PRIVATE_KEY }}
```

With this change your dockerfile also need to be updated to allow Github App to download private package. Add this two ARGs in ur build stage and ur git config --global to pass these two ARGs in url.

```
# Github Username & Token to access private go modules
ARG GITHUB_USERNAME
ARG GITHUB_TOKEN

RUN git config --global url.https://"$GITHUB_USERNAME":"$GITHUB_TOKEN"@github.com/.insteadOf https://github.com/ && \
    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o /app/islb ./cmd/islb
```

