### PR TITLE
feat(workflows): reusable workflows for the lazy + snapshot npm release pattern

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -203,6 +203,180 @@ jobs:
             DEPLOYMENT_APP_PRIVATE_KEY: ${{ secrets.DEPLOYMENT_APP_PRIVATE_KEY }}
 ```
 
+## NPM Lazy + Snapshot Release Pattern
+
+Four reusable workflows for npm projects (single package or multi-package
+workspaces) that follow the **lazy + snapshot release** model. The pattern:
+
+| Branch     | Trigger    | What runs               | Dist-tag |
+|------------|------------|-------------------------|----------|
+| `develop`  | every push | snapshot publish        | `@alpha` |
+| `*/rc`     | every push | snapshot publish        | `@next`  |
+| `main`     | every push | stable publish          | `@latest`|
+
+**Lazy version bumps**: `changeset version` (the real one, no `--snapshot`)
+runs only at the actual release ceremony — manually on the rc branch before
+opening the rc → main PR. develop and rc publish snapshots that mutate
+package.json transiently in CI and never commit. This avoids GitHub's
+anti-recursion gotcha entirely (`GITHUB_TOKEN`-authenticated pushes don't
+trigger downstream workflows), so plain `GITHUB_TOKEN` is sufficient — no PAT
+or App-token needed.
+
+**Per-package detection** in `npm-snapshot-publish` ensures only packages
+whose version actually changed (because a pending changeset affected them)
+are published; unchanged packages are skipped.
+
+Canonical implementation: see [mssfoobar/aa-cli](https://github.com/mssfoobar/aa-cli).
+
+### Workflows
+
+#### `npm-pr-validation.yml`
+
+PR-validation gate. Runs lint / format-check (both opt-in) / typecheck /
+build / test from the repo root or a working directory.
+
+```yaml
+on:
+  pull_request:
+    branches: [develop]
+jobs:
+  validate:
+    uses: mssfoobar/.github/.github/workflows/npm-pr-validation.yml@main
+    with:
+      node-version: '20'
+      run-lint: true
+      run-format-check: true
+```
+
+#### `changeset-check.yml`
+
+Required check that enforces every PR carries a `.changeset/*.md` file (or
+marker-less changeset for no-bump changes). Skips dependabot PRs and the
+`changeset-release/*` branch automatically.
+
+```yaml
+on:
+  pull_request:
+    branches: [develop]
+jobs:
+  check:
+    uses: mssfoobar/.github/.github/workflows/changeset-check.yml@main
+```
+
+#### `npm-snapshot-publish.yml`
+
+Publishes a snapshot version on every push to develop or `*/rc`. Mutates
+package.json transiently via `changeset version --snapshot=<tag>.<run_number>`,
+then publishes only packages whose version actually changed. Versions look
+like `0.1.0-alpha.123` (paired with `prereleaseTemplate: "{tag}"` in
+`.changeset/config.json`).
+
+```yaml
+on:
+  push:
+    branches: [develop, '*/rc']
+jobs:
+  publish-alpha:
+    if: github.ref == 'refs/heads/develop'
+    uses: mssfoobar/.github/.github/workflows/npm-snapshot-publish.yml@main
+    with:
+      tag: alpha
+      scope: '@mssfoobar'
+
+  publish-rc:
+    if: endsWith(github.ref, '/rc')
+    uses: mssfoobar/.github/.github/workflows/npm-snapshot-publish.yml@main
+    with:
+      tag: rc
+      scope: '@mssfoobar'
+```
+
+The consuming repo must define `release:alpha` and `release:rc` npm scripts
+in its root `package.json`. Example:
+
+```json
+{
+  "scripts": {
+    "release:alpha": "npm publish --workspaces --tag alpha",
+    "release:rc":    "npm publish --workspaces --tag next"
+  }
+}
+```
+
+(Single-package repos drop `--workspaces`.)
+
+#### `npm-stable-publish.yml`
+
+Publishes the stable release on push to main, after the rc → main PR has
+merged with a real `changeset version` commit baked in. Uses
+`changesets/action@v1` in publish mode — idempotent, only publishes
+packages whose version isn't already on the registry, creates a GitHub
+Release per published package.
+
+```yaml
+on:
+  push:
+    branches: [main]
+jobs:
+  publish:
+    uses: mssfoobar/.github/.github/workflows/npm-stable-publish.yml@main
+    with:
+      scope: '@mssfoobar'
+```
+
+The consuming repo must define `release:stable`:
+
+```json
+{
+  "scripts": {
+    "release:stable": "npm publish --workspaces"
+  }
+}
+```
+
+### Required `.changeset/config.json` block
+
+```json
+{
+  "snapshot": {
+    "useCalculatedVersion": true,
+    "prereleaseTemplate": "{tag}"
+  }
+}
+```
+
+`useCalculatedVersion: true` makes the snapshot reflect the natural
+next-version trajectory (`0.1.0-alpha.123` rather than `0.0.0-alpha.123`).
+`prereleaseTemplate: "{tag}"` is a passthrough — the snapshot id from the
+CLI becomes the entire prerelease portion.
+
+### Branch protection — required checks
+
+On the integration branch (typically `develop`):
+- `validate` (from `npm-pr-validation.yml`)
+- `check` (from `changeset-check.yml`)
+
+On main:
+- `validate` only (`check` only fires on PRs into develop).
+
+No bypass actors needed — nothing CI-driven pushes to a protected branch.
+
+### When to use the eager pattern instead
+
+`npm-changeset-release.yml` and `monorepo-changeset-release.yml` (also in
+this repo) use the older **eager-bump** pattern: every push to the watched
+branch consumes pending changesets and commits a version bump back to the
+branch. They require a GitHub App with branch-protection bypass to push
+through ruleset gating. Use them when:
+
+- You want each commit on develop tied to a specific deterministic version
+  (rather than internal testers tracking `@alpha`).
+- The team prefers the eager-bump audit trail over the lazy ceremony.
+
+The lazy + snapshot pattern is the recommended default for new npm
+projects. See [aa-cli's git history](https://github.com/mssfoobar/aa-cli/pulls?q=AOH-7029)
+for the journey of trade-offs that led to it.
+
 ## Troubleshooting
 
 Common issues and solutions:

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,40 @@
+name: Changeset Check
+
+# Reusable required-status check that enforces every PR carries a
+# changeset (or marker-less changeset for no-bump changes). Skips:
+#   * the changesets/action's own version PR (head ref starts with
+#     `changeset-release/`) — that PR by design contains zero pending
+#     changesets because it has just consumed them.
+#   * dependabot PRs — mechanical dep bumps don't merit changesets in
+#     the lazy + snapshot model; they roll into the next regular release.
+#
+# Pair with npm-pr-validation in a calling workflow that triggers on
+# `pull_request: branches: [<integration-branch>]`. Both should be
+# marked as required status checks on the integration branch's ruleset.
+
+on:
+  workflow_call:
+
+jobs:
+  check:
+    name: Check
+    if: ${{ !startsWith(github.head_ref, 'changeset-release/') && github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify changeset present
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --name-only --diff-filter=AM "$BASE_SHA...$HEAD_SHA" | grep -E '^\.changeset/[^/]+\.md$' | grep -v '^\.changeset/README\.md$' >/dev/null; then
+            echo "Changeset found."
+          else
+            echo "::error::No changeset in this PR. Run \`npx changeset\` to add one, or add a marker-less changeset (empty frontmatter) for docs/CI/comment-only changes."
+            exit 1
+          fi

--- a/.github/workflows/npm-pr-validation.yml
+++ b/.github/workflows/npm-pr-validation.yml
@@ -1,0 +1,102 @@
+name: NPM PR Validation
+
+# Reusable PR-validation gate for npm projects following the lazy +
+# snapshot release pattern. Runs lint, format-check, typecheck, build,
+# test as a server-side mirror of the local pre-commit gate. Each step
+# can be opted in/out via inputs.
+#
+# Companion workflows: changeset-check, npm-snapshot-publish,
+# npm-stable-publish.
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        required: false
+        type: string
+        default: '20'
+        description: 'Node.js version'
+      working-directory:
+        required: false
+        type: string
+        default: '.'
+        description: 'Working directory for npm scripts (use the package directory in single-package repos that keep their package.json outside the root; defaults to repo root for workspaces)'
+      cache-dependency-path:
+        required: false
+        type: string
+        default: 'package-lock.json'
+        description: 'Path to lockfile for setup-node cache key'
+      install-from-root:
+        required: false
+        type: boolean
+        default: true
+        description: 'Run `npm ci` from the repo root (true for workspaces; set false for single-package repos that vendor their lockfile in a subdirectory)'
+      legacy-peer-deps:
+        required: false
+        type: boolean
+        default: false
+      run-lint:
+        required: false
+        type: boolean
+        default: false
+        description: 'Run `npm run lint` — opt in only if the project defines this script'
+      run-format-check:
+        required: false
+        type: boolean
+        default: false
+        description: 'Run `npm run format:check` — opt in only if the project defines this script'
+      run-typecheck:
+        required: false
+        type: boolean
+        default: true
+      run-build:
+        required: false
+        type: boolean
+        default: true
+      run-test:
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.cache-dependency-path }}
+
+      - name: Install
+        working-directory: ${{ inputs.install-from-root && '.' || inputs.working-directory }}
+        run: npm ci ${{ inputs.legacy-peer-deps && '--legacy-peer-deps' || '' }}
+
+      - name: Lint
+        if: inputs.run-lint
+        run: npm run lint
+
+      - name: Format check
+        if: inputs.run-format-check
+        run: npm run format:check
+
+      - name: Type check
+        if: inputs.run-typecheck
+        run: npm run typecheck
+
+      - name: Build
+        if: inputs.run-build
+        run: npm run build
+
+      - name: Test
+        if: inputs.run-test
+        run: npm test

--- a/.github/workflows/npm-snapshot-publish.yml
+++ b/.github/workflows/npm-snapshot-publish.yml
@@ -1,0 +1,144 @@
+name: NPM Snapshot Publish
+
+# Reusable snapshot publish for the lazy + snapshot release pattern.
+# develop → publishes with --tag alpha; */rc → publishes with --tag next.
+# cli/package.json (or each workspace's package.json) is mutated
+# transiently by `changeset version --snapshot=<id>` and never committed.
+#
+# Per-package detection: in workspace projects, only packages whose
+# version actually changed (because a pending changeset affected them)
+# are published. Packages whose version didn't move are skipped — their
+# existing registry version remains current.
+#
+# The snapshot id is `<tag>.<github.run_number>`, producing clean
+# sequential versions like `0.1.0-alpha.123` (paired with a changesets
+# config that has `prereleaseTemplate: "{tag}"` and
+# `useCalculatedVersion: true`).
+#
+# Auth: plain GITHUB_TOKEN. No PAT or App-token needed because nothing
+# pushes back to a protected branch — `cli/package.json`'s git state is
+# untouched after the workflow exits.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: 'Snapshot id prefix and release-script suffix. Use "alpha" for develop pushes, "rc" for */rc pushes. The workflow runs `npm run release:<tag>`.'
+      node-version:
+        required: false
+        type: string
+        default: '20'
+      scope:
+        required: true
+        type: string
+        description: 'npm scope for GitHub Packages auth (e.g. "@mssfoobar")'
+      legacy-peer-deps:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    name: Publish snapshot (${{ inputs.tag }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node + GitHub Packages registry
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+          scope: ${{ inputs.scope }}
+
+      - name: Install
+        run: npm ci ${{ inputs.legacy-peer-deps && '--legacy-peer-deps' || '' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Snapshot pre-bump versions
+        run: |
+          node -e "
+            const fs = require('fs');
+            const root = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            const workspaces = root.workspaces || [];
+            const targets = workspaces.length ? workspaces : ['.'];
+            const versions = {};
+            for (const ws of targets) {
+              const path = ws === '.' ? 'package.json' : ws + '/package.json';
+              try {
+                const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+                if (pkg.private) continue;
+                versions[pkg.name] = { version: pkg.version, path: ws };
+              } catch (e) {
+                // Workspace entry without a package.json — skip silently.
+              }
+            }
+            fs.writeFileSync('/tmp/pre-versions.json', JSON.stringify(versions));
+            console.log('Pre-bump versions:');
+            for (const [name, info] of Object.entries(versions)) {
+              console.log('  ' + name + ' @ ' + info.version + ' (' + info.path + ')');
+            }
+          "
+
+      - name: Compute snapshot version
+        run: npx changeset version --snapshot=${{ inputs.tag }}.${{ github.run_number }}
+
+      - name: Detect changed packages and publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          # rc → npm dist-tag "next"; everything else uses tag verbatim
+          NPM_TAG=$([ "$TAG" = "rc" ] && echo "next" || echo "$TAG")
+          export NPM_TAG
+
+          node -e "
+            const fs = require('fs');
+            const { execSync } = require('child_process');
+            const pre = JSON.parse(fs.readFileSync('/tmp/pre-versions.json', 'utf8'));
+            const root = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            const workspaces = root.workspaces || [];
+            const targets = workspaces.length ? workspaces : ['.'];
+            const npmTag = process.env.NPM_TAG;
+
+            const changed = [];
+            for (const ws of targets) {
+              const path = ws === '.' ? 'package.json' : ws + '/package.json';
+              try {
+                const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+                if (pkg.private) continue;
+                const oldVersion = pre[pkg.name]?.version;
+                if (oldVersion && oldVersion !== pkg.version) {
+                  changed.push({ name: pkg.name, path: ws, oldVersion, newVersion: pkg.version });
+                }
+              } catch {}
+            }
+
+            if (changed.length === 0) {
+              console.log('No packages changed — nothing to publish.');
+              return;
+            }
+
+            console.log('Publishing ' + changed.length + ' package(s) with --tag ' + npmTag + ':');
+            for (const pkg of changed) {
+              console.log('  ' + pkg.name + ': ' + pkg.oldVersion + ' → ' + pkg.newVersion);
+            }
+            for (const pkg of changed) {
+              const cmd = pkg.path === '.'
+                ? 'npm publish --tag ' + npmTag
+                : 'npm publish --workspace ' + pkg.path + ' --tag ' + npmTag;
+              console.log('\\n\$ ' + cmd);
+              execSync(cmd, { stdio: 'inherit' });
+            }
+          "

--- a/.github/workflows/npm-stable-publish.yml
+++ b/.github/workflows/npm-stable-publish.yml
@@ -1,0 +1,76 @@
+name: NPM Stable Publish
+
+# Reusable stable publish for the lazy + snapshot release pattern.
+# Runs on push to the stable branch (typically `main`) AFTER the
+# rc → main PR has merged. The version commit (cli/package.json bump
+# + CHANGELOG) was already produced manually on the rc branch via
+# `npx changeset version` before that PR opened.
+#
+# Uses changesets/action@v1 in publish mode — it reads each workspace
+# package's version, compares to the registry, and publishes only
+# those that aren't already there. Idempotent: re-runs are safe.
+#
+# `createGithubReleases: true` produces a GitHub Release for each newly
+# published package. Pre-release versions are auto-marked as
+# "Pre-release" in GitHub's UI.
+
+on:
+  workflow_call:
+    inputs:
+      release-script:
+        required: false
+        type: string
+        default: 'release:stable'
+        description: 'npm script the action runs to actually publish (e.g. "release:stable", "release"). Should publish all workspace packages with the default `latest` dist-tag.'
+      node-version:
+        required: false
+        type: string
+        default: '20'
+      scope:
+        required: true
+        type: string
+        description: 'npm scope for GitHub Packages auth (e.g. "@mssfoobar")'
+      create-github-releases:
+        required: false
+        type: boolean
+        default: true
+      legacy-peer-deps:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    name: Publish stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node + GitHub Packages registry
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+          scope: ${{ inputs.scope }}
+
+      - name: Install
+        run: npm ci ${{ inputs.legacy-peer-deps && '--legacy-peer-deps' || '' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish via changesets/action
+        uses: changesets/action@v1
+        with:
+          publish: npm run ${{ inputs.release-script }}
+          createGithubReleases: ${{ inputs.create-github-releases }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Codifies the lazy + snapshot release pattern from \`mssfoobar/aa-cli\` (AOH-7029) as four new org-level reusable workflows. Purely additive — existing reusables (\`npm-changeset-release\`, \`monorepo-changeset-release\`, \`npm-ci\`) are untouched.

## What's new

- **\`npm-pr-validation.yml\`** — PR gate (lint / format-check / typecheck / build / test, each opt-in). Companion to \`changeset-check\`.
- **\`changeset-check.yml\`** — required-status check enforcing every PR carries a changeset (marker-less for no-bump). Auto-skips dependabot and \`changeset-release/*\` branches.
- **\`npm-snapshot-publish.yml\`** — develop / \`*/rc\` snapshot publishes. Per-package detection: only packages whose version moved are published. Snapshot id is \`<tag>.<github.run_number>\`, producing clean \`0.1.0-alpha.123\` versions.
- **\`npm-stable-publish.yml\`** — main stable publish via \`changesets/action\` publish mode (idempotent, createGithubReleases on by default).

All four use plain \`GITHUB_TOKEN\` — the lazy model means CI never pushes to a protected branch, so anti-recursion is sidestepped entirely (no PAT, no App-token bypass-actor needed).

## When to use which pattern

The README's new "NPM Lazy + Snapshot Release Pattern" section documents:

- Full usage examples for each workflow
- Required \`.changeset/config.json\` block (\`snapshot.useCalculatedVersion\`, \`prereleaseTemplate: "{tag}"\`)
- Required \`package.json\` scripts (\`release:alpha\`, \`release:rc\`, \`release:stable\`)
- Required branch-protection checks
- When to use the eager pattern instead

## First consumer

\`mssfoobar/aoh-web-lib\` (separate PR) — wires up against these reusables.

\`mssfoobar/aa-cli\`'s current implementation lives inline in its own \`release.yml\`. Migrating it to call these reusables is a separate small follow-up so it's not blocking this PR.

## Test plan

- [ ] These reusables only get exercised by callers, so no CI runs in this repo verify them.
- [ ] First real exercise: \`aoh-web-lib\` PR will show the alpha-snapshot path working live.
- [ ] If issues surface, hot-fix on this PR's branch (or follow-up) before tagging consumers to a stable ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)