### PR TITLE
chore(workflows): align action versions to v4 in new reusables

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/npm-pr-validation.yml
+++ b/.github/workflows/npm-pr-validation.yml
@@ -68,10 +68,10 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm

--- a/.github/workflows/npm-snapshot-publish.yml
+++ b/.github/workflows/npm-snapshot-publish.yml
@@ -49,12 +49,12 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Node + GitHub Packages registry
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm

--- a/.github/workflows/npm-stable-publish.yml
+++ b/.github/workflows/npm-stable-publish.yml
@@ -49,12 +49,12 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Node + GitHub Packages registry
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm


### PR DESCRIPTION
Small cleanup follow-up to #10. The four reusables added in that PR used \`actions/checkout@v6\` and \`actions/setup-node@v6\`, which worked in integration tests but were the only \`@v6\` outliers in the repo — every other reusable here pins \`@v4\`.

Bumps the four to \`@v4\` for consistency with org conventions.

\`\`\`
$ grep -E "uses: actions/(checkout|setup-node)@" .github/workflows/*.yml | grep v6
(none after this PR)
\`\`\`

## Verification path

The reusables are exercised live by [\`aoh-web-lib#10\`](https://github.com/mssfoobar/aoh-web-lib/pull/10), which references them via \`@main\`. After this PR merges, that PR's next CI run picks up the \`@v4\` versions automatically — that's the integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)