### PR TITLE
fix(npm-snapshot-publish): exit cleanly when no packages changed

### DIFF
--- a/.github/workflows/npm-snapshot-publish.yml
+++ b/.github/workflows/npm-snapshot-publish.yml
@@ -127,7 +127,7 @@ jobs:
 
             if (changed.length === 0) {
               console.log('No packages changed — nothing to publish.');
-              return;
+              process.exit(0);
             }
 
             console.log('Publishing ' + changed.length + ' package(s) with --tag ' + npmTag + ':');


### PR DESCRIPTION
## Summary

- Top-level `return` in a `node -e` script throws `SyntaxError: Illegal return statement`. The early-exit branch in the *Detect changed packages and publish* step took that path when an upstream PR merges without a changeset for any non-private package — and failed instead of exiting cleanly.
- Caught it on `mssfoobar/aoh-web-lib` after PR #9 (auth-sdk port) merged without a changeset; develop's snapshot publish run failed: https://github.com/mssfoobar/aoh-web-lib/actions/runs/25363279346
- One-character fix: `return;` → `process.exit(0);`.

## Test plan

- [ ] Re-run the failed `aoh-web-lib` `Release` workflow on develop after merge — expect the `publish-alpha` job to succeed with "No packages changed — nothing to publish." in the logs.
- [ ] Subsequent `aoh-web-lib` PRs that *do* include a changeset publish normally (i.e. the happy path is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)