### PR TITLE
fix(claude-actions): switch to API-key auth, skip cleanly when missing

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,25 +17,50 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
+
     steps:
+      # Auth note: Anthropic blocks Claude subscription-based access
+      # (the OAuth token path) for this repo specifically — every PR
+      # fails with "Your organization has disabled Claude subscription
+      # access for Claude Code · Use an Anthropic API key instead, or
+      # ask your admin to enable access". OAuth still works in
+      # consumer repos (aa-cli, aoh-web-lib).
+      #
+      # Workaround: use ANTHROPIC_API_KEY when present, otherwise skip
+      # the action cleanly so PRs aren't littered with red checks.
+      # Admin TODO: provision ANTHROPIC_API_KEY at the org secret level
+      # to re-enable reviews here.
+      - name: Check Claude auth availability
+        id: auth
+        env:
+          API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$API_KEY" ]; then
+            echo "method=api_key" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Claude Code Review skipped: ANTHROPIC_API_KEY org secret is not configured. Anthropic blocks the OAuth-token path for this repo; provisioning the API key at the org level re-enables reviews here."
+            echo "method=skip" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
+        if: steps.auth.outputs.method != 'skip'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
+        if: steps.auth.outputs.method != 'skip'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,13 +50,13 @@ jobs:
           fi
 
       - name: Checkout repository
-        if: steps.auth.outputs.method != 'skip'
+        if: success() && steps.auth.outputs.method == 'api_key'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        if: steps.auth.outputs.method != 'skip'
+        if: success() && steps.auth.outputs.method == 'api_key'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,13 +43,13 @@ jobs:
           fi
 
       - name: Checkout repository
-        if: steps.auth.outputs.method != 'skip'
+        if: success() && steps.auth.outputs.method == 'api_key'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
-        if: steps.auth.outputs.method != 'skip'
+        if: success() && steps.auth.outputs.method == 'api_key'
         id: claude
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,17 +25,36 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      # Auth: ANTHROPIC_API_KEY is required for this repo because
+      # Anthropic blocks the OAuth subscription path for `mssfoobar/
+      # .github` specifically. See claude-code-review.yml for the
+      # full note. Skip cleanly when the secret is missing so an
+      # `@claude` mention doesn't generate a failing run.
+      - name: Check Claude auth availability
+        id: auth
+        env:
+          API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$API_KEY" ]; then
+            echo "method=api_key" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Claude Code skipped: ANTHROPIC_API_KEY org secret is not configured. Anthropic blocks the OAuth-token path for this repo; provisioning the API key at the org level re-enables @claude mentions here."
+            echo "method=skip" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
+        if: steps.auth.outputs.method != 'skip'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
+        if: steps.auth.outputs.method != 'skip'
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Summary

Fixes the chronic claude-review failure on every PR opened against this repo: every run errors with *"Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access"*. Anthropic blocks the OAuth subscription path for \`mssfoobar/.github\` specifically — OAuth still works in the consumer repos (aa-cli, aoh-web-lib), so this is repo-specific at Anthropic's backend.

Two changes per workflow (\`claude-code-review.yml\` + \`claude.yml\`):

1. **Switch the action input from \`claude_code_oauth_token\` → \`anthropic_api_key\`.** This is the path Anthropic's error message directs to.
2. **Add a guard step that skips the action cleanly when \`ANTHROPIC_API_KEY\` isn't set.** Today, the secret isn't provisioned yet — without the guard, every run would just turn red for a different reason (empty key). With the guard, runs go green with a \`::warning::\` annotation explaining the skip.

**Admin TODO** (gates re-enabling the reviews):
- Provision an \`ANTHROPIC_API_KEY\` org secret. Once present, both workflows just start running again.

## Test plan

- [ ] After merge: open a no-op PR against this repo. The Claude Code Review check should be green (skipped via the guard, not failed via Anthropic).
- [ ] Annotation message visible in the run UI explaining the skip.
- [ ] Once \`ANTHROPIC_API_KEY\` is provisioned: open a PR and verify the action actually runs and posts a review comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)