### PR TITLE
fix(reusables): export NODE_AUTH_TOKEN on PR-validation install steps

### DIFF
--- a/.github/workflows/npm-pr-validation.yml
+++ b/.github/workflows/npm-pr-validation.yml
@@ -108,11 +108,20 @@ jobs:
         if: inputs.package-manager == 'npm'
         working-directory: ${{ inputs.install-from-root && '.' || inputs.working-directory }}
         run: npm ci ${{ inputs.legacy-peer-deps && '--legacy-peer-deps' || '' }}
+        env:
+          # Authenticate against GitHub Packages for private @mssfoobar deps.
+          # The publish reusables already export this; PR-validation was
+          # missing it. With pnpm + optional peers, fresh CI installs hit
+          # ERR_PNPM_FETCH_401 without it (npm escapes today only because
+          # `npm ci` doesn't materialize optional peer deps).
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install (pnpm)
         if: inputs.package-manager == 'pnpm'
         working-directory: '.'
         run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
         if: inputs.run-lint

--- a/.github/workflows/npm-pr-validation.yml
+++ b/.github/workflows/npm-pr-validation.yml
@@ -21,6 +21,11 @@ on:
         type: string
         default: ''
         description: '(pnpm only) Explicit pnpm version, e.g. `10.16.1`. If empty, pnpm/action-setup resolves the version from `package.json#packageManager`. Ignored for npm.'
+      scope:
+        required: false
+        type: string
+        default: ''
+        description: 'NPM scope to wire to the GitHub Packages registry, e.g. `@mssfoobar`. When set, `setup-node` writes a user-level `.npmrc` with `<scope>:registry=https://npm.pkg.github.com` and `//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}`. Required if any install dep (including optional peers pnpm resolves into the lockfile) lives on GitHub Packages and the consumer does not already pin the registry in a checked-in `.npmrc`. Mirrors the publish reusables.'
       node-version:
         required: false
         type: string
@@ -74,6 +79,13 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Be self-sufficient about token scope rather than inheriting from the
+    # caller. Many consumer workflows don't declare `packages: read` (or run
+    # under restricted-default tokens), which would silently 401 the install
+    # for any private @org dep. Mirrors the publish reusables.
+    permissions:
+      contents: read
+      packages: read
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -97,12 +109,17 @@ jobs:
         with:
           version: ${{ inputs.pnpm-version }}
 
-      - name: Set up Node
+      - name: Set up Node + GitHub Packages registry
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
           cache: ${{ inputs.package-manager }}
           cache-dependency-path: ${{ inputs.cache-dependency-path != '' && inputs.cache-dependency-path || (inputs.package-manager == 'pnpm' && 'pnpm-lock.yaml' || 'package-lock.json') }}
+          # Wire the GitHub Packages registry for the supplied scope so
+          # `NODE_AUTH_TOKEN` resolves at install time. Pairs with the env
+          # block on the install steps; one without the other is a no-op.
+          registry-url: 'https://npm.pkg.github.com'
+          scope: ${{ inputs.scope }}
 
       - name: Install (npm)
         if: inputs.package-manager == 'npm'


### PR DESCRIPTION
## Why

\`npm-pr-validation.yml\` was the only reusable in this repo missing \`env: NODE_AUTH_TOKEN: \${{ secrets.GITHUB_TOKEN }}\` on its install steps. Every other reusable that runs \`npm ci\` / \`pnpm install\` sets it:

\`\`\`
npm-snapshot-publish.yml          ✓ has it
npm-stable-publish.yml            ✓ has it
npm-changeset-release.yml         ✓ has it
npm-build-publish.yml             ✓ has it
monorepo-changeset-release.yml    ✓ has it
modlet-build-publish.yml          ✓ has it
npm-pr-validation.yml             ✗ missing  ← this PR
\`\`\`

Almost certainly an oversight when #13 added the pnpm path.

## Symptom in consumers

In \`mssfoobar/aoh-web-lib\`, \`pnpm install --frozen-lockfile\` fails on every PR with:

\`\`\`
ERR_PNPM_FETCH_401  GET https://npm.pkg.github.com/download/@mssfoobar/sds-client/1.0.0/...: Unauthorized
\`\`\`

because the lockfile pins \`@mssfoobar/sds-client\` (an optional peer of \`auth-sdk\`) to the GitHub Packages tarball URL and pnpm has no auth token to reach it. The npm path escapes today only because \`npm ci\` doesn't materialize optional peer deps — the same correctness gap exists, just dormant.

## Fix

Add the env block to both install steps (npm + pnpm) for parity:

\`\`\`yaml
- name: Install (pnpm)
  ...
  run: pnpm install --frozen-lockfile
  env:
    NODE_AUTH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
\`\`\`

\`secrets.GITHUB_TOKEN\` is auto-provided to workflow_call, so consumer workflows don't need to plumb anything through.

## Risk

Minimal — additive env block on existing steps. The token is the same one publish workflows already use. Will validate by running the consumer's PR (\`mssfoobar/aoh-web-lib#14\`) against the new \`@main\` once this lands.

## Test plan

- [ ] Merge to main
- [ ] Re-run a failing pnpm-mode consumer PR (aoh-web-lib#14) and confirm \`Install (pnpm)\` step now succeeds