### PR TITLE
feat(reusables): add opt-in audit step to PR validation

### DIFF
--- a/.github/workflows/npm-pr-validation.yml
+++ b/.github/workflows/npm-pr-validation.yml
@@ -73,6 +73,16 @@ on:
         required: false
         type: boolean
         default: true
+      run-audit:
+        required: false
+        type: boolean
+        default: false
+        description: '(opt-in) Run `npm audit --omit=dev` / `pnpm audit --prod` after install. Fails the job on any advisory at `audit-severity` or above.'
+      audit-severity:
+        required: false
+        type: string
+        default: 'high'
+        description: '(audit only) Minimum advisory severity that fails the job: `info`, `low`, `moderate`, `high`, or `critical`. Default `high`.'
 
 jobs:
   validate:
@@ -139,6 +149,18 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Audit (npm)
+        if: inputs.run-audit && inputs.package-manager == 'npm'
+        env:
+          AUDIT_LEVEL: ${{ inputs.audit-severity }}
+        run: npm audit --omit=dev --audit-level="$AUDIT_LEVEL"
+
+      - name: Audit (pnpm)
+        if: inputs.run-audit && inputs.package-manager == 'pnpm'
+        env:
+          AUDIT_LEVEL: ${{ inputs.audit-severity }}
+        run: pnpm audit --prod --audit-level "$AUDIT_LEVEL"
 
       - name: Lint
         if: inputs.run-lint


### PR DESCRIPTION
Companion to <issue id="AOH-7082" /> — adds an opt-in audit gate to \`npm-pr-validation.yml\`. Consumers wire it on by passing \`run-audit: true\`.

## What

Two new inputs:

- \`run-audit\` (bool, default \`false\`) — runs \`npm audit --omit=dev\` or \`pnpm audit --prod\` after install
- \`audit-severity\` (string, default \`'high'\`) — minimum advisory level that fails the job

Two new steps that fire only when \`run-audit\` is true:

\`\`\`yaml
- name: Audit (npm)
  if: inputs.run-audit && inputs.package-manager == 'npm'
  env:
    AUDIT_LEVEL: \${{ inputs.audit-severity }}
  run: npm audit --omit=dev --audit-level=\"\$AUDIT_LEVEL\"

- name: Audit (pnpm)
  if: inputs.run-audit && inputs.package-manager == 'pnpm'
  env:
    AUDIT_LEVEL: \${{ inputs.audit-severity }}
  run: pnpm audit --prod --audit-level \"\$AUDIT_LEVEL\"
\`\`\`

## Why opt-in

Existing consumers shouldn't see new red checks unannounced. Once a project audits clean, they flip the input on.

## Test plan

- [ ] Existing consumers with \`run-audit\` unset see no behaviour change
- [ ] aoh-web-lib follow-up will set \`run-audit: true\` once this lands