### PR TITLE
ci(npm-snapshot-publish): add runner input for self-hosted execution

### DIFF
--- a/.github/workflows/npm-snapshot-publish.yml
+++ b/.github/workflows/npm-snapshot-publish.yml
@@ -76,11 +76,16 @@ on:
         type: boolean
         default: false
         description: 'When true, log the publish/skip decision per package and publish nothing.'
+      runner:
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label to execute on. Defaults to GitHub-hosted ubuntu-latest; set to a self-hosted scale-set label (e.g. "arc-runner") to run the publish on self-hosted runners.'
 
 jobs:
   publish:
     name: Publish snapshot (${{ inputs.tag }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 10
     permissions:
       contents: read


### PR DESCRIPTION
Mirror the `runner` input already on `changeset-check.yml`.

Consumers behind a GitHub Actions billing/spending block can pass a self-hosted scale-set label (e.g. `arc-runner`) so the snapshot publish runs on self-hosted runners instead of billing-failing at startup on `ubuntu-latest`. Defaults to `ubuntu-latest`, so existing callers are unaffected.

Motivation: ops-hub's `release.yml` (alpha snapshots) currently billing-fails on every develop-branch event because this reusable is hardcoded to `ubuntu-latest`. After this merges, ops-hub will pin the new SHA and pass `runner: arc-runner`.
