### PR TITLE
ci(npm-build-publish): add runner input for self-hosted execution

### DIFF
--- a/.github/workflows/npm-build-publish.yml
+++ b/.github/workflows/npm-build-publish.yml
@@ -18,10 +18,15 @@ on:
                 type: string
                 description: "The npm repository to publish to"
                 default: "https://npm.pkg.github.com/"
+            runner:
+                required: false
+                type: string
+                default: "ubuntu-latest"
+                description: 'Runner label to execute on. Defaults to GitHub-hosted ubuntu-latest; set to a self-hosted scale-set label (e.g. "arc-runner") to run the publish on self-hosted runners.'
 
 jobs:
     build-and-publish:
-        runs-on: ubuntu-latest
+        runs-on: ${{ inputs.runner }}
         defaults:
             run:
                 working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
Mirror the runner input already on npm-snapshot-publish.yml and changeset-check.yml. Consumers behind a GitHub Actions billing/spending block can pass a self-hosted scale-set label (e.g. arc-runner) so the publish runs on self-hosted runners instead of billing-failing at startup on ubuntu-latest. Defaults to ubuntu-latest, so existing callers are unaffected.

<!-- Please fill in the following information before submitting your pull request: -->
## Description

<!-- 
  If this pull request is linked to an issue on Linear, please use the magic word link:
  https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

