### PR TITLE
fix(npm-build-publish): set up Node.js before any node-dependent step

### DIFF
--- a/.github/workflows/npm-build-publish.yml
+++ b/.github/workflows/npm-build-publish.yml
@@ -38,6 +38,13 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
+            - name: Set up Node.js ${{ inputs.node-version }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ inputs.node-version }}
+                  cache: "npm"
+                  registry-url: ${{ inputs.npm-repository }}
+
             - name: Extract version from release tag
               id: version
               run: |
@@ -54,61 +61,8 @@ jobs:
                     exit 1
                   fi
 
-            - name: Determine paths and lockfile for caching
-              id: paths
-              working-directory: ${{ github.workspace }}
-              run: |
-                  ABS_INPUT_WORKING_DIR=$(realpath "${{ inputs.working-directory }}")
-                  echo "Input working directory (absolute): $ABS_INPUT_WORKING_DIR"
-
-                  if [ ! -d "$ABS_INPUT_WORKING_DIR" ]; then
-                    echo "::error::Input working directory '${{ inputs.working-directory }}' (resolved to '$ABS_INPUT_WORKING_DIR') does not exist."
-                    exit 1
-                  fi
-
-                  NPM_ROOT_OUTPUT_FROM_INPUT_WD=$(cd "$ABS_INPUT_WORKING_DIR" && npm root)
-                  EFFECTIVE_PROJECT_ROOT=$(dirname "$NPM_ROOT_OUTPUT_FROM_INPUT_WD")
-
-                  echo "effective_project_root=${EFFECTIVE_PROJECT_ROOT}" >> $GITHUB_OUTPUT
-                  echo "abs_input_working_dir=${ABS_INPUT_WORKING_DIR}" >> $GITHUB_OUTPUT
-
-                  # Determine the path to the package-lock.json for caching
-                  if [ "$EFFECTIVE_PROJECT_ROOT" == "$ABS_INPUT_WORKING_DIR" ]; then
-                    TARGET_LOCKFILE_PATH="${ABS_INPUT_WORKING_DIR}/package-lock.json"
-                  else
-                    TARGET_LOCKFILE_PATH="${EFFECTIVE_PROJECT_ROOT}/package-lock.json"
-                  fi
-
-                  if [ -f "$TARGET_LOCKFILE_PATH" ]; then
-                    echo "lock_file_for_cache=$TARGET_LOCKFILE_PATH" >> $GITHUB_OUTPUT
-                  else
-                    echo "lock_file_for_cache=**/package-lock.json" >> $GITHUB_OUTPUT
-                    echo "::warning::Lockfile not found at '$TARGET_LOCKFILE_PATH'. Falling back to default glob for caching."
-                  fi
-
-            - name: Set up Node.js ${{ inputs.node-version }}
-              uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ inputs.node-version }}
-                  cache: "npm"
-                  cache-dependency-path: ${{ steps.paths.outputs.lock_file_for_cache }}
-                  registry-url: ${{ inputs.npm-repository }}
-
             - name: Install dependencies
-              working-directory: ${{ github.workspace }}
-              run: |
-                  if [ "${{ steps.paths.outputs.effective_project_root }}" == "${{ steps.paths.outputs.abs_input_working_dir }}" ]; then
-                    INSTALL_DIR="${{ steps.paths.outputs.abs_input_working_dir }}"
-                  else
-                    INSTALL_DIR="${{ steps.paths.outputs.effective_project_root }}"
-                  fi
-
-                  if [ -z "$INSTALL_DIR" ]; then
-                    echo "::error::Could not determine the directory for 'npm ci'."
-                    exit 1
-                  fi
-
-                  cd "$INSTALL_DIR" && npm ci --ignore-scripts
+              run: npm ci --ignore-scripts
 
             - name: Build package
               run: npm run build

--- a/.github/workflows/npm-build-publish.yml
+++ b/.github/workflows/npm-build-publish.yml
@@ -62,6 +62,7 @@ jobs:
                   fi
 
             - name: Install dependencies
+              working-directory: ${{ github.workspace }}
               run: npm ci --ignore-scripts
 
             - name: Build package


### PR DESCRIPTION
Self-hosted arc-runners don't have Node preinstalled, so the workflow failed at the "Verify tag matches package.json version" step (which calls node -p) and at the previous "Determine paths and lockfile for caching" step (which called npm root). Move actions/setup-node to run immediately after checkout so every subsequent step has Node available.

Drop the paths/lockfile probing and the conditional install logic — they relied on npm being available before setup-node ran, and setup-node's npm cache works fine with the default lockfile discovery.

<!-- Please fill in the following information before submitting your pull request: -->
## Description

<!-- 
  If this pull request is linked to an issue on Linear, please use the magic word link:
  https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

